### PR TITLE
Fix bug when TEXMF contains conlon-separated list

### DIFF
--- a/mtpro2-texlive.sh
+++ b/mtpro2-texlive.sh
@@ -39,6 +39,8 @@ echo "$(tex --version)" >> $LOGFILE
 UPDCFG=`kpsewhich updmap.cfg`
 echo "updmap.cfg is at $UPDCFG" >> $LOGFILE
 TEXMF=`kpsewhich --var-value TEXMFLOCAL`
+# get first element if TEXMF is colon-seperated list
+TEXMF=${TEXMF%%:*}
 echo "The texmf directory for fonts is $TEXMF" >> $LOGFILE
 
 


### PR DESCRIPTION
On my machine (ArchLinux) TEXMF contains `/usr/local/share/texmf:/usr/share/texmf`

The script created this directory with colon and installed all files there :)

The fix just uses first value of colon-separated list.